### PR TITLE
Add Behance and Landing.jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot -w djangojobs.net README.md
+  - awesome_bot -w djangojobs.net,landing.jobs README.md

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A curated list of awesome niche job boards.
 - [Growth Hacking](#growth-hacking)
 - [Programming](#programming)
 - [Remote](#remote)
+- [Tech](#tech)
 
 ## Big Data
 
@@ -26,12 +27,13 @@ A curated list of awesome niche job boards.
 
 ## Design
 
-* [Jobs for Designers](https://dribbble.com/jobs)
-* [UX Jobs Board](https://www.uxjobsboard.com)
 * [AIGA](http://designjobs.aiga.org/)
 * [IXDA](http://www.ixda.org/page/job-board)
-* [Krop](http://www.krop.com/creative-jobs/)
+* [Behance](https://www.behance.net/joblist)
 * [Coroflot](http://www.coroflot.com/jobs)
+* [Jobs for Designers](https://dribbble.com/jobs)
+* [Krop](http://www.krop.com/creative-jobs/)
+* [UX Jobs Board](https://www.uxjobsboard.com)
 
 ## Growth Hacking
 
@@ -100,3 +102,9 @@ A curated list of awesome niche job boards.
 
 * [GoRemote](https://goremote.io/)
 * [remote | OK](https://remoteok.io/)
+
+## Tech
+
+### Europe
+
+* [Landing.jobs](https://landing.jobs/?utm_source=github&utm_medium=referral&utm_content=whfio&utm_campaign=post)


### PR DESCRIPTION
This commit adds two new job boards: https://www.behance.net/joblist
and https://landing.jobs.  Additionally, we sort the Design jobs and
also add Landing.jobs to the linting whitelist.  We also create a new
category (Tech) for Landing.jobs.