### PR TITLE
Update Support Ops Job Board

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A curated list of awesome niche job boards.
 
 ## Customer Support
 
-* [Support Ops Job Board](http://jobs.supportops.co/)
+* [Support Driven Jobs](http://jobs.supportdriven.com/)
 
 ## Design
 


### PR DESCRIPTION
According to http://jobs.supportops.co/, this job board has since
merged with http://jobs.supportdriven.com/.