### PR TITLE
Update lint failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot -w djangojobs.net,landing.jobs README.md
+  - awesome_bot -w dribbble.com README.md

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A curated list of awesome niche job boards.
 * [Behance](https://www.behance.net/joblist)
 * [Coroflot](http://www.coroflot.com/design-jobs)
 * [Jobs for Designers](https://dribbble.com/jobs)
-* [Krop](http://www.krop.com/creative-jobs/)
+* [Krop](https://www.krop.com/creative-jobs/)
 * [Open Source Design Jobs](http://opensourcedesign.net/jobs/)
 * [UX Jobs Board](https://www.uxjobsboard.com)
 * [Design Inc.](https://www.designinc.com)


### PR DESCRIPTION
Update krop.com to use https and whitelist dribbble.com since it's
returning an ssl error.

We also remove djangojobs.net,landing.jobs from whitelist since those
now pass successfully.