### PR TITLE
remove dup link

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ A curated list of awesome niche job boards.
 
 ### Go
 
-* [Golang Projects](https://www.golangprojects.com/)
+* [Golangprojects](https://www.golangprojects.com/)
 * [we love golang](https://www.welovegolang.com/)
 * [Golang Forum Jobs](https://forum.golangbridge.org/c/jobs)
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,9 @@ A curated list of awesome niche job boards.
 
 ### Go
 
-* [Golang / Go Jobs & Developers](https://www.golangprojects.com/)
+* [Golang Projects](https://www.golangprojects.com/)
 * [we love golang](https://www.welovegolang.com/)
 * [Golang Forum Jobs](https://forum.golangbridge.org/c/jobs)
-* [Golang Projects](https://www.golangprojects.com)
 
 ### JavaScript
 


### PR DESCRIPTION
I noticed there were two links to golangprojects.com with two different text in the Go section.  Just removed one and kept it in the same position in the list.  Happy job searching!